### PR TITLE
Return Error With Message in Spending Requirements

### DIFF
--- a/src/spending_requirements.rs
+++ b/src/spending_requirements.rs
@@ -107,7 +107,7 @@ impl P2WSHChecker {
             ScriptBuf::from_bytes(script.to_vec()),
             witness,
         )
-        .map_err(|_| Error::msg("The script cannot be executed."))?;
+        .map_err(|e| Error::msg(format!("The script cannot be executed: {:?}", e)))?;
         loop {
             if exec.exec_next().is_err() {
                 break;
@@ -189,7 +189,7 @@ impl P2TRChecker {
             ScriptBuf::from_bytes(script_buf),
             witness,
         )
-        .map_err(|_| Error::msg("The script cannot be executed."))?;
+        .map_err(|e| Error::msg(format!("The script cannot be executed: {:?}", e)))?;
         loop {
             if exec.exec_next().is_err() {
                 break;


### PR DESCRIPTION
While executing Bitcoin script in `spending_requirements`, Bitcoin's error message is not returned to caller. This PR addresses that issue.